### PR TITLE
Display recurring events and whole-day events correctly

### DIFF
--- a/ftw/calendar/tests/test_calendar_json_source.py
+++ b/ftw/calendar/tests/test_calendar_json_source.py
@@ -1,4 +1,4 @@
-from ftw.builder import Builder
+from ftw.builder.dexterity import DexterityBuilder
 from ftw.builder import create
 from ftw.calendar.browser.calendarupdateview import CalendarJSONSource
 from ftw.calendar.browser.interfaces import IFtwCalendarJSONSourceProvider
@@ -20,8 +20,7 @@ class TestCalendarSource(TestCase):
         self.portal = self.layer['portal']
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
         login(self.portal, TEST_USER_NAME)
-
-        self.event = create(Builder('event'))
+        self.event = create(DexterityBuilder('event'))
 
     def test_adapter_provides_methods(self):
         verifyObject(IFtwCalendarJSONSourceProvider, CalendarJSONSource(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.1.2.dev0'
+version = '2.1.3.dev0'
 
 tests_require = ['ftw.testing [splinter]',
                  'ftw.builder',


### PR DESCRIPTION
In order to display recurring and whole-day events correctly we needed to a couple of changes to calendarupdateview.py: changed to use the existing get_events code:
 `from plone.app.event.base import get_events`

I'm not sure if this is taking things a step away from the initial design parameters, but thought it might be something that you / others found helpful if wanting to use the calendar view on Plone 5 with recurring and/or all-day events.
